### PR TITLE
Add a max_diff_ratio column in plan_history table.

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,7 +147,8 @@ Table "plan_repo.plan_history"
 	 scan_hint        | text                        | Scan_hint of this plan
 	 join_hint        | text                        | Join_hint of this plan
 	 lead_hint        | text                        | Leading_hint of this plan
-	 diff_of_joins    | numeric                     | Sum of estimation row error of joins (NULL means no estimation error) 
+	 diff_of_joins    | numeric                     | Sum of estimation row error of joins (NULL means no estimation error)
+	 max_diff_ratio   | numeric                     | Maximum estimation row error ratio of joins
 	 join_cnt         | integer                     | Join number of this plan
 	 application_name | text                        | Application name of client tool such as "psql"
 	 timestamp        | timestamp without time zone | Timestamp of this record inserted

--- a/pg_plan_advsr--0.0.sql
+++ b/pg_plan_advsr--0.0.sql
@@ -21,6 +21,7 @@ CREATE TABLE plan_repo.plan_history
 	lead_hint			text,
 --	diff_of_joins		numeric,
 	diff_of_joins		double precision,
+	max_diff_ratio		double precision,
 	join_cnt			int,
 	application_name	text,
 	timestamp			timestamp


### PR DESCRIPTION
With the example given in the readme, the explain is:

```
                                                          QUERY PLAN                                                           
-------------------------------------------------------------------------------------------------------------------------------
 Hash Join  (cost=7905.92..31080.92 rows=500000 width=16) (actual time=19.892..435.362 rows=201 loops=1)
   Hash Cond: (t2.a = t1.a)
   CTE x
     ->  Limit  (cost=0.00..2.90 rows=201 width=8) (actual time=0.104..0.360 rows=201 loops=1)
           ->  Seq Scan on t1 t1_1  (cost=0.00..14425.00 rows=1000000 width=8) (actual time=0.098..0.249 rows=201 loops=1)
   ->  Seq Scan on t2  (cost=0.00..14425.00 rows=1000000 width=8) (actual time=0.073..162.262 rows=1000000 loops=1)
   ->  Hash  (cost=1653.02..1653.02 rows=500000 width=12) (actual time=8.721..8.721 rows=201 loops=1)
         Buckets: 524288  Batches: 1  Memory Usage: 4105kB
         ->  Nested Loop  (cost=4.95..1653.02 rows=500000 width=12) (actual time=1.665..8.158 rows=201 loops=1)
               ->  HashAggregate  (cost=4.52..6.52 rows=200 width=4) (actual time=1.556..1.930 rows=201 loops=1)
                     Group Key: x.a
                     ->  CTE Scan on x  (cost=0.00..4.02 rows=201 width=4) (actual time=0.117..0.938 rows=201 loops=1)
               ->  Index Scan using i_t1_a on t1  (cost=0.42..8.22 rows=1 width=8) (actual time=0.025..0.026 rows=1 loops=201)
                     Index Cond: (a = x.a)
 Planning time: 3.958 ms
 Execution time: 437.727 ms
(16 rows)
```

Which give the following record in the plan_history table:
```
-[ RECORD 1 ]----+--------------------------------------
id               | 1
norm_query_hash  | 140ca282219d84960f765b68d7d99706
pgsp_queryid     | 4173287301
pgsp_planid      | 3707748199
execution_time   | 435.418776
rows_hint        | ROWS(t2 t1 x #201)                   +
                 | ROWS(t1 x #201) 
scan_hint        | SEQSCAN(t2) SEQSCAN(x) INDEXSCAN(t1) 
join_hint        | HASHJOIN(t2 t1 x)                    +
                 | NESTLOOP(t1 x) 
lead_hint        | LEADING( (t2 (x t1 )) )
diff_of_joins    | 999598
max_diff_ratio   | 2487.56218905473
join_cnt         | 2
application_name | psql
timestamp        | 2020-06-24 19:43:54.11382
```